### PR TITLE
Fixed material transparency in phong shader

### DIFF
--- a/GVRf/Framework/framework/src/main/res/raw/fragment_template.fsh
+++ b/GVRf/Framework/framework/src/main/res/raw/fragment_template.fsh
@@ -32,13 +32,11 @@ struct Radiance
 
 void main()
 {
-	vec3 color = vec3(0, 0, 0);
 	Surface s = @ShaderName();
 #if defined(HAS_LIGHTSOURCES)
-	color = LightPixel(s);
-	color = clamp(color, vec3(0), vec3(1));
+	vec4 color = LightPixel(s);
+	fragColor = clamp(color, vec4(0), vec4(1));
 #else
-	color = s.diffuse.xyz;
+	fragColor = s.diffuse;
 #endif
-	fragColor = vec4(color.x, color.y, color.z, 1.0);
 }

--- a/GVRf/Framework/framework/src/main/res/raw/phong_surface.fsh
+++ b/GVRf/Framework/framework/src/main/res/raw/phong_surface.fsh
@@ -41,6 +41,7 @@ Surface @ShaderName()
 #ifdef HAS_opacityTexture
 	diffuse.w *= texture(opacityTexture, diffuse_coord.xy).a;
 #endif
+diffuse.xyz *= diffuse.w;
 #ifdef HAS_specularTexture
 	specular *= texture(specularTexture, diffuse_coord.xy);
 #endif


### PR DESCRIPTION
The Phong shader was ignoring the alpha in the diffuse color of the
material. Now it is correctly applying it.
