### PR TITLE
Added GVRScriptBehavior scripting component

### DIFF
--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRBehavior.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRBehavior.java
@@ -36,7 +36,7 @@ import java.lang.reflect.Method;
 public class GVRBehavior extends GVRComponent implements GVRDrawFrameListener
 {
     protected boolean mIsListening;
-    private boolean mHasFrameCallback;
+    protected boolean mHasFrameCallback;
     static private long TYPE_BEHAVIOR = (System.currentTimeMillis() & 0xfffffff);
     
     /**
@@ -69,12 +69,14 @@ public class GVRBehavior extends GVRComponent implements GVRDrawFrameListener
         return TYPE_BEHAVIOR;
     }
     
-    public void enable()
+    @Override
+    public void onEnable()
     {
         startListening();
     }
 
-    public void disable()
+    @Override
+    public void onDisable()
     {
         stopListening();
     }
@@ -107,7 +109,6 @@ public class GVRBehavior extends GVRComponent implements GVRDrawFrameListener
         stopListening();
     }
     
-
     /**
      * Called each frame before rendering the scene.
      * It is not called if this behavior is not attached

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVREventListeners.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVREventListeners.java
@@ -41,6 +41,12 @@ public class GVREventListeners {
         @Override
         public void onStep() {
         }
+        
+        @Override
+        public void onAttach(Object target) { }
+        
+        @Override
+        public void onDetach(Object target) { }
     }
 
     /**

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRScene.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRScene.java
@@ -19,6 +19,7 @@ import org.gearvrf.GVRRenderData.GVRRenderMaskBit;
 import org.gearvrf.debug.GVRConsole;
 import org.gearvrf.script.IScriptable;
 import org.gearvrf.utility.Log;
+import org.gearvrf.script.GVRScriptBehavior;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -565,7 +566,11 @@ public class GVRScene extends GVRHybridObject implements PrettyPrint, IScriptabl
         private void recursivelySendOnInit(GVRSceneObject sceneObject) {
             getGVRContext().getEventManager().sendEvent(
                     sceneObject, ISceneObjectEvents.class, "onInit", getGVRContext(), sceneObject);
-
+            GVRScriptBehavior script = (GVRScriptBehavior) sceneObject.getComponent(GVRScriptBehavior.getComponentType());
+            if (script != null) {
+                getGVRContext().getEventManager().sendEvent(
+                        script, ISceneEvents.class, "onInit", getGVRContext(), GVRScene.this);
+            }
             for (GVRSceneObject child : sceneObject.rawGetChildren()) {
                 recursivelySendOnInit(child);
             }

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRScript.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/GVRScript.java
@@ -104,6 +104,20 @@ public abstract class GVRScript implements IScriptEvents, IScriptable, IEventRec
     }
 
     /**
+     * Called when the script is attached to a target using {@link GVRScriptManager#attachScript}.
+     */
+    @Override
+    public void onAttach(Object target) {
+    }
+
+    /**
+     * Called when the script is detached from the target using {@link GVRScriptManager#detachScript}.
+     */
+    @Override
+    public void onDetach(Object target) {
+    }
+    
+    /**
      * Called every frame.
      * 
      * This is where you start animations, and where you add or change

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/IScriptEvents.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/IScriptEvents.java
@@ -25,6 +25,10 @@ public interface IScriptEvents extends IEvents {
     void onInit(GVRContext gvrContext) throws Throwable;
 
     void onAfterInit();
+    
+    void onAttach(Object target);
+    
+    void onDetach(Object target);
 
     void onStep();
 }

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/script/GVRJavascriptScriptFile.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/script/GVRJavascriptScriptFile.java
@@ -40,6 +40,19 @@ public class GVRJavascriptScriptFile extends GVRScriptFile {
         load(inputStream);
     }
 
+    /**
+     * Loads a Javascript file from a text string.
+     *
+     * @param gvrContext
+     *     The GVR Context.
+     * @param scriptText
+     *     String containing a Javascript program.
+     */
+    public GVRJavascriptScriptFile(GVRContext gvrContext, String scriptText) {
+        super(gvrContext, GVRScriptManager.LANG_JAVASCRIPT);
+        setScriptText(scriptText);
+    }
+    
     protected String getInvokeStatement(String eventName, Object[] params) {
         StringBuilder sb = new StringBuilder();
 

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/script/GVRLuaScriptFile.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/script/GVRLuaScriptFile.java
@@ -55,6 +55,19 @@ public class GVRLuaScriptFile extends GVRScriptFile {
         load(inputStream);
     }
 
+    /**
+     * Loads a Lua script from a text string.
+     *
+     * @param gvrContext
+     *     The GVR Context.
+     * @param scriptText
+     *     String containing the text of a LUA program.
+     */
+    public GVRLuaScriptFile(GVRContext gvrContext, String scriptText) {
+        super(gvrContext, GVRScriptManager.LANG_LUA);
+        setScriptText(scriptText);
+    }
+    
     protected String getInvokeStatement(String eventName, Object[] params) {
         StringBuilder sb = new StringBuilder();
         sb.append("return ");

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/script/GVRScriptBehavior.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/script/GVRScriptBehavior.java
@@ -1,0 +1,336 @@
+package org.gearvrf.script;
+
+import java.io.IOException;
+import java.util.HashMap;
+
+import org.gearvrf.GVRAndroidResource;
+import org.gearvrf.GVRBehavior;
+import org.gearvrf.GVRContext;
+import org.gearvrf.GVRResourceVolume;
+import org.gearvrf.GVRScene;
+import org.gearvrf.GVRSceneObject;
+import org.gearvrf.IPickEvents;
+import org.gearvrf.ISceneEvents;
+import org.gearvrf.utility.FileNameUtils;
+import org.gearvrf.GVRPicker;
+import org.gearvrf.IPickEvents;
+import org.gearvrf.ISensorEvents;
+import org.gearvrf.SensorEvent;
+
+/**
+ * Attaches a Java or Lua script to a scene object.
+ * 
+ * These script callbacks are invoked if they are present:
+ *      onEarlyInit(GVRContext) called after script is loaded
+ *      onAfterInit()           called when the script becomes active
+ *                              (this component is attached to a scene object and enabled)
+ *      onStep()                called every frame if this component is enabled
+ *                              and attached to a scene object
+ *      onPickEnter(GVRSceneObject, GVRPicker.GVRPickedObject)
+ *                              called when picking ray enters an object
+ *      onPickExit(GVRSceneObject)
+ *                              called when picking ray exits an object
+ *      onPickInside(GVRSceneObject, GVRPicker.GVRPickedObject)
+ *                              called when picking ray is inside an object
+ *      onPick(GVRPicker)       called when picking selection changes
+ *      onNoPick(GVRPicker)     called when nothing is picked
+ *
+ */
+public class GVRScriptBehavior extends GVRBehavior implements IPickEvents, ISensorEvents, ISceneEvents
+{
+    static private long TYPE_SCRIPT_BEHAVIOR = (System.currentTimeMillis() & 0xfffffff);
+    static private Object[] noargs = new Object[0];
+    protected GVRScriptFile mScriptFile = null;
+    protected boolean mIsAttached = false;
+    protected int mPickEvents = 0xF;
+    protected String mLanguage = GVRScriptManager.LANG_JAVASCRIPT;
+    private String mLastError;
+    private GVRScene mScene = null;
+    
+    /**
+     * Constructor for a script behavior component.
+     * @param gvrContext    The current GVRF context
+     */
+    public GVRScriptBehavior(GVRContext gvrContext)
+    {
+        super(gvrContext);
+        mHasFrameCallback = false;
+        mType = TYPE_SCRIPT_BEHAVIOR;
+        mIsAttached = false;
+        mLanguage = GVRScriptManager.LANG_JAVASCRIPT;
+        gvrContext.getEventReceiver().addListener(this);
+    }
+
+    /**
+     * Constructor for a script behavior component.
+     * @param gvrContext    The current GVRF context
+     * @param scriptFile    Path to the script file.
+     */
+    public GVRScriptBehavior(GVRContext gvrContext, String scriptFile) throws IOException, GVRScriptException
+    {
+        super(gvrContext);
+        mHasFrameCallback = false;
+        mType = TYPE_SCRIPT_BEHAVIOR;
+        mIsAttached = false;
+        mLanguage = GVRScriptManager.LANG_JAVASCRIPT;
+        gvrContext.getEventReceiver().addListener(this);
+        setFilePath(scriptFile);
+    }
+
+    public GVRScriptFile getScriptFile()
+    {
+        return mScriptFile;
+    }
+    
+    /**
+     * Sets the path to the script file to load and loads the script.
+     * 
+     * @param filePath path to script file
+     * @throws IOException
+     * @throws GVRScriptException
+     */
+    public void setFilePath(String filePath) throws IOException, GVRScriptException
+    {
+        GVRResourceVolume.VolumeType volumeType = GVRResourceVolume.VolumeType.ANDROID_ASSETS;
+        String fname = filePath.toLowerCase();
+        
+        mLanguage = FileNameUtils.getExtension(fname);        
+        if (fname.startsWith("sd:"))
+        {
+            volumeType = GVRResourceVolume.VolumeType.ANDROID_SDCARD;
+        }
+        else if (fname.startsWith("http:") || fname.startsWith("https:"))
+        {
+            volumeType = GVRResourceVolume.VolumeType.NETWORK;            
+        }
+        GVRResourceVolume volume = new GVRResourceVolume(getGVRContext(), volumeType,
+                FileNameUtils.getParentDirectory(filePath));
+        GVRAndroidResource resource = volume.openResource(filePath);
+         
+        setScriptFile(getGVRContext().getScriptManager().loadScript(resource, mLanguage));
+    }
+    
+    /**
+     * Loads the script from a text string.
+     * @param scriptText text string containing script to execute.
+     * @param language language ("js" or "lua")
+     */
+    public void setScriptText(String scriptText, String language)
+    {
+        GVRScriptFile newScript;
+        
+        if (language.equals(GVRScriptManager.LANG_LUA))
+        {
+            newScript = new GVRLuaScriptFile(getGVRContext(), scriptText);
+            mLanguage = language;
+        }
+        else
+        {
+            newScript = new GVRJavascriptScriptFile(getGVRContext(), scriptText);
+            mLanguage = GVRScriptManager.LANG_JAVASCRIPT;
+        }
+        setScriptFile(newScript);        
+    }
+    
+    /**
+     * Set the GVRScriptFile to execute.
+     * @param scriptFile GVRScriptFile with script already loaded.
+     * If the script contains a function called "onEarlyInit"
+     * it is called if the script file is valid.
+     */
+    public void setScriptFile(GVRScriptFile scriptFile)
+    {
+        if (mScriptFile != scriptFile)
+        {
+            detachScript();
+            mScriptFile = scriptFile;
+        }
+    }
+    
+    /**
+     * Invokes the script associated with this component.
+     * This function invokes the script even if the
+     * component is not enabled and not attached to
+     * a scene object.
+     * @see GVRScriptFile.invoke
+     */
+    public void invoke()
+    {
+        if (mScriptFile != null)
+        {
+            mScriptFile.invoke();
+        }
+    }
+
+    public void onInit(GVRContext context, GVRScene scene)
+    {
+        mScene = scene;
+        startPicking();
+    }
+
+    public void onAfterInit() { }
+
+    public void onStep() { }
+
+    public void onAttach(GVRSceneObject owner)
+    {
+        super.onAttach(owner);
+        attachScript(owner);
+    }
+
+    public void onEnable()
+    {
+        super.onEnable();
+        attachScript(null);
+    }
+    
+    public void onDetach(GVRSceneObject owner)
+    {
+        detachScript();
+        super.onDetach(owner);
+    }
+    
+    public void onDrawFrame(float frameTime)
+    {
+        invokeFunction("onStep", noargs);
+    }
+
+    public void onEnter(GVRSceneObject sceneObj, GVRPicker.GVRPickedObject hit)
+    {
+         if (!invokeFunction("onPickEnter", new Object[] { sceneObj, hit }))
+         {
+             mPickEvents &= ~1;
+             if (mPickEvents == 0)
+             {
+                 stopPicking();
+             }
+         }
+        org.gearvrf.utility.Log.d("GVRScriptBehavior", "onPickEnter " + sceneObj.getName());
+    }
+
+    public void onExit(GVRSceneObject sceneObj)
+    {
+        if (!invokeFunction("onPickExit", new Object[] { sceneObj }))
+        {
+            mPickEvents &= ~2;
+            if (mPickEvents == 0)
+            {
+                stopPicking();
+            }
+        }
+        org.gearvrf.utility.Log.d("GVRScriptBehavior", "onPickExit " + sceneObj.getName());
+    }
+
+    public void onPick(GVRPicker picker)
+    {
+        if (!invokeFunction("onPick", new Object[] { picker }))
+        {
+            mPickEvents &= ~4;
+            if (mPickEvents == 0)
+            {
+                stopPicking();
+            }
+        }
+    }
+
+    public void onNoPick(GVRPicker picker)
+    {
+       if (!invokeFunction("onNoPick", new Object[] { picker }))
+       {
+           mPickEvents &= ~8;
+           if (mPickEvents == 0)
+           {
+               stopPicking();
+           }
+       }
+    }
+
+    public void onSensorEvent(SensorEvent event)
+    {
+        invokeFunction("onSensorEvent", new Object[] { event });
+    }
+
+    public void onInside(GVRSceneObject sceneObj, GVRPicker.GVRPickedObject hit) { }
+
+    protected void attachScript(GVRSceneObject owner)
+    {
+        if (owner == null)
+        {
+            owner = getOwnerObject();
+        }
+        if (!mIsAttached && (mScriptFile != null) && isEnabled() && (owner != null) && owner.isEnabled())
+        {
+            getGVRContext().getScriptManager().attachScriptFile(owner, mScriptFile);
+            mIsAttached = true;
+            owner.getEventReceiver().addListener(this);
+            if (invokeFunction("onStep", noargs))
+            {
+                mHasFrameCallback = true;
+                startListening();
+            }
+        }
+    }
+
+    protected void startPicking()
+    {
+        GVRScene scene = mScene;
+        mPickEvents = 0xF;
+        if (mScene == null)
+        {
+            scene = getGVRContext().getMainScene();
+        }
+        scene.getEventReceiver().addListener(this);
+    }
+
+    protected void stopPicking()
+    {
+        GVRScene scene = mScene;
+        if (mScene == null)
+        {
+            scene = getGVRContext().getMainScene();
+        }
+        scene.getEventReceiver().removeListener(this);
+    }
+
+    protected void detachScript()
+    {
+        GVRSceneObject owner = getOwnerObject();
+        
+        if (mIsAttached && (owner != null))
+        {
+            getGVRContext().getScriptManager().detachScriptFile(owner);
+            owner.getEventReceiver().removeListener(this);
+            mIsAttached = false;
+            mHasFrameCallback = true;
+            stopPicking();
+            stopListening();
+        }
+    }
+
+    /**
+     * Calls a function script associated with this component.
+     * The function is called even if the component
+     * is not enabled and not attached to a scene object.
+     * @param funcName name of script function to call.
+     * @param params function parameters as an array of objects.
+     * @return true if function was called, false if no such function
+     * @see GVRScriptFile.invokeFunction
+     */
+    public boolean invokeFunction(String funcName, Object[] args)
+    {
+        mLastError = null;
+        if (mScriptFile != null)
+        {
+            if (mScriptFile.invokeFunction(funcName, args))
+            {
+                return true;
+            }
+        }
+        mLastError = mScriptFile.getLastError();
+        if (mLastError != null)
+        {
+            org.gearvrf.utility.Log.e("GVRScriptBehavior", "ScriptError: " + mLastError);
+        }
+        return false;
+    }
+}

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/script/GVRScriptFile.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/script/GVRScriptFile.java
@@ -62,6 +62,7 @@ public abstract class GVRScriptFile {
     // Caching parameter names to reduce object creation
     private static final int sNumOfCachedParamNames = 10;
     private static String[] sCachedParamName;
+    private String mLastError = null;
 
     static {
         // Generate parameter names, arg0, arg1, ...
@@ -139,6 +140,8 @@ public abstract class GVRScriptFile {
         return mScriptText;
     }
 
+    public String getLastError() { return mLastError; }
+
     /**
      * Invokes the script.
      *
@@ -191,6 +194,7 @@ public abstract class GVRScriptFile {
         } catch (ScriptException e) {
             // The function is either undefined or throws, avoid invoking it later
             addBadFunction(funcName);
+            mLastError = e.getMessage();
             return false;
         } finally {
             removeBindings(localBindings, params);
@@ -231,6 +235,7 @@ public abstract class GVRScriptFile {
 
     protected void checkDirty() {
         synchronized (mScriptTextLock) {
+            mLastError = null;
             if (mScriptTextDirty) {
                 mScriptTextDirty = false;
 
@@ -240,6 +245,7 @@ public abstract class GVRScriptFile {
                 try {
                     mLocalEngine.eval(mScriptText);
                 } catch (ScriptException e) {
+                    mLastError = e.getMessage();
                     e.printStackTrace();
                 }
             }

--- a/GVRf/Framework/framework/src/main/java/org/gearvrf/script/GVRScriptManager.java
+++ b/GVRf/Framework/framework/src/main/java/org/gearvrf/script/GVRScriptManager.java
@@ -176,6 +176,7 @@ public class GVRScriptManager {
      */
     public void attachScriptFile(IScriptable target, GVRScriptFile scriptFile) {
         mScriptMap.put(target, scriptFile);
+        scriptFile.invokeFunction("onAttach", new Object[] { target });
     }
 
     /**
@@ -184,7 +185,10 @@ public class GVRScriptManager {
      * @param target The scriptable target.
      */
     public void detachScriptFile(IScriptable target) {
-        mScriptMap.remove(target);
+        GVRScriptFile scriptFile = mScriptMap.remove(target);
+        if (scriptFile != null) {
+            scriptFile.invokeFunction("onDetach", new Object[] { target });
+        }
     }
 
     /**
@@ -367,7 +371,9 @@ public class GVRScriptManager {
                     GVRSceneObject[] sceneObjects = rootSceneObject.getSceneObjectsByName(targetName);
                     if (sceneObjects != null) {
                         for (GVRSceneObject sceneObject : sceneObjects) {
-                            attachScriptFile(sceneObject, scriptFile);
+                            GVRScriptBehavior b = new GVRScriptBehavior(sceneObject.getGVRContext());
+                            b.setScriptFile(scriptFile);
+                            sceneObject.attachComponent(b);
                         }
                     }
                 }


### PR DESCRIPTION
Allows a script to be attached as a component. Sets up event listeners
for picking and draw frame events and directs them to the script.
Directs all events on the scene object to the script.

Modified script manager to attach GVRScriptBehavior component when a
script bundle is loaded. Added onAttach, onDetach script events.

GearVRf-DCO-1.0-Signed-off-by: Nola Donato nola.donato@samsung.com
