### PR TITLE
For initial bringup/debug, select Vulkan rendering through properties

### DIFF
--- a/GVRf/Framework/framework/src/main/jni/engine/renderer/renderer_instance.cpp
+++ b/GVRf/Framework/framework/src/main/jni/engine/renderer/renderer_instance.cpp
@@ -20,21 +20,45 @@
 #include "renderer.h"
 #include "gl_renderer.h"
 #include "vulkan_renderer.h"
+#include <sys/system_properties.h>
+#include <cstring>
 
 namespace gvr {
 Renderer* Renderer::instance = nullptr;
 bool Renderer::isVulkan_ = false;
 
 /***
-    Till we have Vulkan implementation, lets create GLRenderer by-default
+    We are implementing Vulkan. Enable through system properties.
 ***/
 Renderer* Renderer::getInstance(std::string type){
-    if(nullptr == instance){
-     if(0){
+    if( nullptr == instance ) {
+        // Debug setting selecting Vulkan renderer:
+        //     setprop debug.gvrf.vulkan <value>
+        //     <property not present>, <empty>, not recognized, or 0
+        //                            - use setting from gvr.xml (not implemented yet. Select OpenGL ES.)
+        //     1                      - pretend gvr.xml asked for Vulkan (not implemented yet. Select Vulkan.)
+        //     2                      - always use Vulkan.
+        bool useVulkan = false; // TODO: obtain setting from gvr.xml
+        const prop_info *pi = __system_property_find("debug.gearvrf.vulkan");
+        char buffer[PROP_VALUE_MAX];
+        int len = 0;
+        if( pi ) {
+            len = __system_property_read(pi,0,buffer);
+        }
+        if( len ) {
+            if( strcmp(buffer,"1") == 0 || // TODO: "1" should check if Vulkan is supported
+                strcmp(buffer,"2") == 0
+            ) {
+                useVulkan = true;
+                LOGI("Vulkan renderer: debug.gearvrf.vulkan is \"%s\".", buffer );
+            } else {
+                LOGI("OpenGL ES renderer: debug.gearvrf.vulkan is \"%s\".", buffer );
+            }
+        }
+        if( useVulkan ) {
             instance = new VulkanRenderer();
             isVulkan_ = true;
-        }
-        else {
+        } else {
             instance = new GLRenderer();
         }
     }


### PR DESCRIPTION
In lieu of the manual:
adb shell setprop gebug.gearvrf.vulkan 0 # or unset: OpenGL ES
adb shell setprop gebug.gearvrf.vulkan 1 # Vulkan (where available)
adb shell setprop debug.gearvrf.vulkan 2 # Vulkan unconditionally